### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -1,5 +1,7 @@
 ---
 name: Development Environment
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sommerfeld-io/.github/security/code-scanning/16](https://github.com/sommerfeld-io/.github/security/code-scanning/16)

To fix the problem, add an explicit `permissions` block to the workflow YAML file to limit the GITHUB_TOKEN permissions to only those necessary for the workflow. Since the workflow only needs to read repository contents (for checking out code and linting/building), set `contents: read`. The best place to add this is at the root level of the YAML file (immediately after `name:`), so all jobs in the workflow inherit these restricted permissions, unless they specify more permissive settings.

Edit .github/workflows/dev-environment.yml to insert:
```yaml
permissions:
  contents: read
```
on a new line after `name: Development Environment`. No extra imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
